### PR TITLE
Added Implementations of `__copy__` and `__deepcopy__` to show which objects are allowed to be copied and which not.

### DIFF
--- a/cuvis/AcquisitionContext.py
+++ b/cuvis/AcquisitionContext.py
@@ -536,6 +536,15 @@ class AcquisitionContext(object):
         cuvis_il.cuvis_acq_cont_free(_ptr)
         self._handle = cuvis_il.p_int_value(_ptr)
 
+    def __deepcopy__(self, memo):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Deep copying is not supported for AcquisitionContext')
+
+    def __copy__(self):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError(
+            'Shallow copying is not supported for AcquisitionContext')
+
 
 class Component:
     """

--- a/cuvis/Async.py
+++ b/cuvis/Async.py
@@ -66,6 +66,15 @@ class AsyncMesu(object):
         cuvis_il.cuvis_async_capture_free(_ptr)
         self._handle = cuvis_il.p_int_value(_ptr)
 
+    def __deepcopy__(self, memo):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Deep copying is not supported for AsyncMesu')
+
+    def __copy__(self):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError(
+            'Shallow copying is not supported for AsyncMesu')
+
 
 class Async(object):
     def __init__(self, handle):
@@ -111,3 +120,12 @@ class Async(object):
         cuvis_il.p_int_assign(_ptr, self._handle)
         cuvis_il.cuvis_async_call_free(_ptr)
         self._handle = cuvis_il.p_int_value(_ptr)
+
+    def __deepcopy__(self, memo):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Deep copying is not supported for Async')
+
+    def __copy__(self):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError(
+            'Shallow copying is not supported for Async')

--- a/cuvis/Calibration.py
+++ b/cuvis/Calibration.py
@@ -60,3 +60,11 @@ class Calibration(object):
         _ptr = cuvis_il.new_p_int()
         cuvis_il.p_int_assign(_ptr, self._handle)
         cuvis_il.cuvis_calib_free(_ptr)
+
+    def __deepcopy__(self, memo):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Deep copying is not supported for Calibration')
+
+    def __copy__(self):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Shallow copying is not supported for Calibration')

--- a/cuvis/Export.py
+++ b/cuvis/Export.py
@@ -4,6 +4,7 @@ from .cuvis_aux import SDKException
 from .Measurement import Measurement
 from .FileWriteSettings import GeneralExportSettings, EnviExportSettings, TiffExportSettings, ViewExportSettings, SaveArgs
 
+
 class Exporter(object):
     def __init__(self):
         self._handle = None
@@ -25,6 +26,14 @@ class Exporter(object):
     def flush(self):
         if cuvis_il.status_ok != cuvis_il.cuvis_exporter_flush(self._handle):
             raise SDKException()
+
+    def __deepcopy__(self, memo):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Deep copying is not supported for Exporter')
+
+    def __copy__(self):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Shallow copying is not supported for Exporter')
 
     @property
     def queue_used(self) -> int:

--- a/cuvis/Measurement.py
+++ b/cuvis/Measurement.py
@@ -237,3 +237,10 @@ class Measurement(object):
         cuvis_il.cuvis_measurement_free(_ptr)
         self._handle = cuvis_il.p_int_value(_ptr)
         pass
+
+    def __deepcopy__(self, memo):
+        return self.deepcopy()
+
+    def __copy__(self, memo):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Shallow copying is not supported for Measurement')

--- a/cuvis/ProcessingContext.py
+++ b/cuvis/ProcessingContext.py
@@ -12,6 +12,7 @@ from typing import Union
 
 import dataclasses
 
+
 class ProcessingContext(object):
     def __init__(self, base: Union[Calibration, SessionFile, Measurement]):
         self._handle = None
@@ -133,3 +134,12 @@ class ProcessingContext(object):
         cuvis_il.cuvis_proc_cont_free(_ptr)
         self._handle = cuvis_il.p_int_value(_ptr)
         pass
+
+    def __deepcopy__(self, memo):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Deep copying is not supported for ProcessingContext')
+
+    def __copy__(self):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError(
+            'Shallow copying is not supported for ProcessingContext')

--- a/cuvis/SessionFile.py
+++ b/cuvis/SessionFile.py
@@ -104,3 +104,11 @@ class SessionFile(object):
         cuvis_il.p_int_assign(_ptr, self._handle)
         cuvis_il.cuvis_session_file_free(_ptr)
         self._handle = cuvis_il.p_int_value(_ptr)
+
+    def __deepcopy__(self, memo):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Deep copying is not supported for SessionFile')
+
+    def __copy__(self):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Shallow copying is not supported for SessionFile')

--- a/cuvis/Viewer.py
+++ b/cuvis/Viewer.py
@@ -67,3 +67,11 @@ class Viewer(object):
         cuvis_il.p_int_assign(_ptr, self._handle)
         cuvis_il.cuvis_viewer_free(_ptr)
         self._handle = cuvis_il.p_int_value(_ptr)
+
+    def __deepcopy__(self, memo):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Deep copying is not supported for Viewer')
+
+    def __copy__(self):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Shallow copying is not supported for Viewer')

--- a/cuvis/Worker.py
+++ b/cuvis/Worker.py
@@ -318,3 +318,11 @@ class Worker(object):
         cuvis_il.p_int_assign(_ptr, self._handle)
         cuvis_il.cuvis_worker_free(_ptr)
         self._handle = cuvis_il.p_int_value(_ptr)
+
+    def __deepcopy__(self, memo):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Deep copying is not supported for Worker')
+
+    def __copy__(self):
+        '''This functions is not permitted due to the class only keeping a handle, that is managed by the cuvis sdk.'''
+        raise TypeError('Shallow copying is not supported for Worker')


### PR DESCRIPTION
If an object is not allowed to be copied, the `__copy__` or `__deepcopy__` functions is implemented but will raise a `TypeError` on execution.
Currently only `Measurement` has support for a deep copy operation (out of all the objects that manage a handle)
For objects that do not manage a sdk handle, the normal python copy behaviour is enough.